### PR TITLE
Add Prices Table

### DIFF
--- a/backend/stonks/db/migrations/20241230033711_add_prices_table.ts
+++ b/backend/stonks/db/migrations/20241230033711_add_prices_table.ts
@@ -1,16 +1,19 @@
 import type { Knex } from 'knex';
 
-const tableName = 'securities';
-const validTypes = ['STOCK', 'BOND', 'ETF', 'CRYPTO'];
+const tableName = 'prices';
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable(tableName, (table) => {
     table.uuid('id').primary().notNullable().defaultTo(knex.fn.uuid());
     table.timestamp('created').notNullable().defaultTo(knex.fn.now());
     table.timestamp('updated').notNullable().defaultTo(knex.fn.now());
-    table.text('ticker').notNullable();
-    table.text('type').notNullable().checkIn(validTypes);
-    table.text('name');
+    table.uuid('securityId').notNullable().references('id').inTable('securities');
+    table.date('tradingDate').notNullable();
+    table.integer('open').notNullable();
+    table.integer('high').notNullable();
+    table.integer('low').notNullable();
+    table.integer('close').notNullable();
+    table.integer('volume').notNullable();
   });
 }
 


### PR DESCRIPTION
# Description

^

## Changelog

- [x] Add prices table to store historical price data for given securities

## Testing

- [x] Ran up, down, and up migrations and confirmed they work as expected